### PR TITLE
fixed case when request does not contain Perun data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+[Fixed]
+- Fix for situation when request does not contain Perun data
 
 ## [v1.3.1]
 [Fixed]


### PR DESCRIPTION
Fix for corner case when the request comes without information from Perun.
This happens when user comes from Perun SP.

Added detection of this state and disabled writing information to Perun
as there would be no place to write it to.

Signed-off-by: Petr Vsetecka <vsetecka@cesnet.cz>