### PR TITLE
Set the default LoA to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+[Fixed]
+- Set the default LoA to 0 for IdP without or with empty attribute 'entityCategory'
 
 ## [v1.4.0]
-[Chahnged]
+[Changed]
 - Changed ComputeLoA Process filter to add LoA=2 for people from university with affiliation='alum'  
 
 [Fixed]

--- a/lib/Auth/Process/ComputeLoA.php
+++ b/lib/Auth/Process/ComputeLoA.php
@@ -80,7 +80,7 @@ class sspmod_cesnet_Auth_Process_ComputeLoA extends SimpleSAML_Auth_ProcessingFi
 	private function getLoA() {
 
 		if (is_null($this->entityCategory) || empty($this->entityCategory)) {
-			return 2;
+			return 0;
 		} elseif ($this->entityCategory === self::UNIVERSITY) {
 			foreach ($this->eduPersonScopedAffiliation as $affiliation) {
 				if (preg_match("/(^employee@.+\.cz$)|(^faculty@.+\.cz$)|(^member@.+\.cz$)|(^student@.+\.cz$)|(^staff@.+\.cz$)|(^alum@.+\.cz$)/", $affiliation, $matches)) {


### PR DESCRIPTION
* Set the default LoA to 0 for IdP without or with empty attribute 'entityCategory'