### PR TITLE
fix for empty LDAP response in IsCesnetEligible::getAllowedAffiliations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+[Fixed]
+- Added verification for empty response from LDAP in IsCesnetEligible::getAllowedAffiliations which is valid state
 
 ## [v1.4.1]
 [Fixed]

--- a/lib/Auth/Process/IsCesnetEligible.php
+++ b/lib/Auth/Process/IsCesnetEligible.php
@@ -139,12 +139,18 @@ class sspmod_cesnet_Auth_Process_IsCesnetEligible extends SimpleSAML_Auth_Proces
 		try {
 			$affiliations = $this->cesnetLdapConnector->searchForEntity(self::ORGANIZATION_LDAP_BASE,'(entityIDofIdP=' . $idpEntityId . ')', array(
 				'cesnetcustomeraffiliation'))['cesnetcustomeraffiliation'];
-			foreach ($affiliations as $affiliation) {
-				array_push($allowedAffiliations, $affiliation);
+
+			if (empty($affiliations)) {
+				SimpleSAML\Logger::debug("cesnet:IsCesnetEligible - Received empty response from LDAP, entityId " . $idpEntityId . " was probably not found.");
+			} else {
+				foreach ($affiliations as $affiliation) {
+					array_push($allowedAffiliations, $affiliation);
+				}
 			}
 		} catch (Exception $ex) {
 			SimpleSAML\Logger::warning("cesnet:IsCesnetEligible - Unable to connect to LDAP!");
 		}
+
 		return $allowedAffiliations;
 	}
 }


### PR DESCRIPTION
Fixed bug that was throwing error when LDAP does not find given IdP.
That is a valid state as given IdP might not yet have been added to LDAP or it might be Social IdP which will never be part of LDAP.